### PR TITLE
Update to Qt 6.11.0

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -24,20 +24,20 @@ jobs:
         ]
         include:
           - name: linux-x86_64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             arch: x86_64
           - name: macos-x86_64
-            os: macos-12
+            os: macos-14
             arch: x86_64
           - name: macos-arm64
             os: macos-14
             arch: arm64
           - name: windows-x86_64
-            os: windows-2019
+            os: windows-2022
             arch: x86_64
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build windows
       if: contains(matrix.os, 'windows')
       shell: powershell
@@ -64,10 +64,12 @@ jobs:
           libgl1-mesa-dev \
           libglu1-mesa-dev \
           libxcb-*-dev \
-          libclang-12-dev \
-          llvm-12
+          curl
+
+        curl -O https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 20
         apt list --installed
-        sudo apt remove llvm-10 clang-10
         make ARCH=${{ matrix.arch }}
         echo UPLOAD_FILE=cutter-deps-qt-linux-${{ matrix.arch }}.tar.gz >> $GITHUB_ENV
         echo UPLOAD_ASSET_TYPE=application/gzip >> $GITHUB_ENV

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -37,7 +37,7 @@ jobs:
             arch: x86_64
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: build windows
       if: contains(matrix.os, 'windows')
       shell: powershell
@@ -73,7 +73,7 @@ jobs:
         make ARCH=${{ matrix.arch }}
         echo UPLOAD_FILE=cutter-deps-qt-linux-${{ matrix.arch }}.tar.gz >> $GITHUB_ENV
         echo UPLOAD_ASSET_TYPE=application/gzip >> $GITHUB_ENV
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: startsWith(github.event.ref, 'refs/tags') == false
       with:
         name: ${{ env.UPLOAD_FILE }}

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -73,7 +73,7 @@ jobs:
         make ARCH=${{ matrix.arch }}
         echo UPLOAD_FILE=cutter-deps-qt-linux-${{ matrix.arch }}.tar.gz >> $GITHUB_ENV
         echo UPLOAD_ASSET_TYPE=application/gzip >> $GITHUB_ENV
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: startsWith(github.event.ref, 'refs/tags') == false
       with:
         name: ${{ env.UPLOAD_FILE }}

--- a/Makefile
+++ b/Makefile
@@ -76,64 +76,27 @@ else
   endef
 endif
 
+SKIP_MODULES := qtwebengine qt3d qtcanvas3d qtcharts qtconnectivity qtdeclarative \
+                qtdoc qtscript qtdatavis3d qtgamepad qtlocation qtgraphicaleffects \
+                qtmultimedia qtpurchasing qtscxml qtsensors qtserialbus qtserialport \
+                qtspeech qttranslations qtvirtualkeyboard qtwebglplugin qtwebsockets \
+                qtwebview qtmacextras qtwayland qtquickcontrols qtquickcontrols2 \
+                qtx11extras qtandroidextras qtwebchannel qtquick3d qtgraphs qtlottie \
+                qtactiveqt qtcoap qtgrpc qthttpserver qtlanguageserver qtnetworkauth \
+                qtopcua qtpositioning qtquick3dphysics qtquickeffectmaker \
+                qtremoteobjects qtmqtt qtshadertools qtcanvaspainter qtquicktimeline
+
 ifeq (${PLATFORM},win)
+  7Z_EXCLUDES := $(addprefix -x!${QT_SRC_DIR}/, $(SKIP_MODULES))
+
   define extract
-	7z x "$1" -bsp1 \
-		-x'!'${QT_SRC_DIR}/qtwebengine \
-		-x'!'${QT_SRC_DIR}/qt3d \
-		-x'!'${QT_SRC_DIR}/qtcanvas3d \
-		-x'!'${QT_SRC_DIR}/qtcharts \
-		-x'!'${QT_SRC_DIR}/qtconnectivity \
-		-x'!'${QT_SRC_DIR}/qtdeclarative \
-		-x'!'${QT_SRC_DIR}/qtdoc \
-		-x'!'${QT_SRC_DIR}/qtscript \
-		-x'!'${QT_SRC_DIR}/qtdatavis3d \
-		-x'!'${QT_SRC_DIR}/qtgamepad \
-		-x'!'${QT_SRC_DIR}/qtlocation \
-		-x'!'${QT_SRC_DIR}/qtgraphicaleffects \
-		-x'!'${QT_SRC_DIR}/qtmultimedia \
-		-x'!'${QT_SRC_DIR}/qtpurchasing \
-		-x'!'${QT_SRC_DIR}/qtscxml \
-		-x'!'${QT_SRC_DIR}/qtsensors \
-		-x'!'${QT_SRC_DIR}/qtserialbus \
-		-x'!'${QT_SRC_DIR}/qtserialport \
-		-x'!'${QT_SRC_DIR}/qtspeech \
-		-x'!'${QT_SRC_DIR}/qttranslations \
-		-x'!'${QT_SRC_DIR}/qtvirtualkeyboard \
-		-x'!'${QT_SRC_DIR}/qtwebglplugin \
-		-x'!'${QT_SRC_DIR}/qtwebsockets \
-		-x'!'${QT_SRC_DIR}/qtwebview \
-		-x'!'${QT_SRC_DIR}/qtmacextras \
-		-x'!'${QT_SRC_DIR}/qtwayland \
-		-x'!'${QT_SRC_DIR}/qtquickcontrols \
-		-x'!'${QT_SRC_DIR}/qtquickcontrols2 \
-		-x'!'${QT_SRC_DIR}/qtx11extras \
-		-x'!'${QT_SRC_DIR}/qtandroidextras \
-		-x'!'${QT_SRC_DIR}/qtwebchannel \
-		-x'!'${QT_SRC_DIR}/qtquick3d \
-		-x'!'${QT_SRC_DIR}/qtgraphs \
-		-x'!'${QT_SRC_DIR}/qtlottie \
-		-x'!'${QT_SRC_DIR}/qtactiveqt \
-		-x'!'${QT_SRC_DIR}/qtcoap \
-		-x'!'${QT_SRC_DIR}/qtgrpc \
-		-x'!'${QT_SRC_DIR}/qthttpserver \
-		-x'!'${QT_SRC_DIR}/qtlanguageserver \
-		-x'!'${QT_SRC_DIR}/qtnetworkauth \
-		-x'!'${QT_SRC_DIR}/qtopcua \
-		-x'!'${QT_SRC_DIR}/qtpositioning \
-		-x'!'${QT_SRC_DIR}/qtquick3dphysics \
-		-x'!'${QT_SRC_DIR}/qtquickeffectmaker \
-		-x'!'${QT_SRC_DIR}/qtremoteobjects \
-		-x'!'${QT_SRC_DIR}/qtmqtt \
-		-x'!'${QT_SRC_DIR}/qtmultimedia \
-		-x'!'${QT_SRC_DIR}/qtshadertools \
-		-x'!'${QT_SRC_DIR}/qtdeclarative \
-		-x'!'${QT_SRC_DIR}/qtcanvaspainter \
-		-x'!'${QT_SRC_DIR}/qtquicktimeline
+	7z x "$1" -bsp1 $(7Z_EXCLUDES)
   endef
 else
+  TAR_EXCLUDES := $(addprefix --exclude=, $(SKIP_MODULES))
+
   define extract
-	tar -xf "$1"
+	tar -xf "$1" $(TAR_EXCLUDES)
   endef
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,15 @@ endif
 #BASE_URL=http://www.mirrorservice.org/sites/download.qt-project.org
 BASE_URL=https://download.qt.io
 
-QT_VER_FULL=6.7.2
-QT_VER_SHORT=6.7
+QT_VER_FULL=6.11.0
+QT_VER_SHORT=6.11
 ifeq (${PLATFORM},win)
 QT_SRC_FILE=qt-everywhere-src-${QT_VER_FULL}.zip
-QT_SRC_MD5=69c87bb306ab78b988fb69819c32f3de
+QT_SRC_MD5=a0c1765cfd135eed64a3c0535cf27318
 QT_SRC_URL=${BASE_URL}/official_releases/qt/${QT_VER_SHORT}/${QT_VER_FULL}/single/${QT_SRC_FILE}
 else
 QT_SRC_FILE=qt-everywhere-src-${QT_VER_FULL}.tar.xz
-QT_SRC_MD5=06d35b47349c7c0a45710daad359e07b
+QT_SRC_MD5=a93e9f424a9d11ee8d67bf8fb1af4772
 QT_SRC_URL=${BASE_URL}/official_releases/qt/${QT_VER_SHORT}/${QT_VER_FULL}/single/${QT_SRC_FILE}
 endif
 
@@ -109,7 +109,27 @@ ifeq (${PLATFORM},win)
 		-x'!'${QT_SRC_DIR}/qtquickcontrols2 \
 		-x'!'${QT_SRC_DIR}/qtx11extras \
 		-x'!'${QT_SRC_DIR}/qtandroidextras \
-		-x'!'${QT_SRC_DIR}/qtwebchannel
+		-x'!'${QT_SRC_DIR}/qtwebchannel \
+		-x'!'${QT_SRC_DIR}/qtquick3d \
+		-x'!'${QT_SRC_DIR}/qtgraphs \
+		-x'!'${QT_SRC_DIR}/qtlottie \
+		-x'!'${QT_SRC_DIR}/qtactiveqt \
+		-x'!'${QT_SRC_DIR}/qtcoap \
+		-x'!'${QT_SRC_DIR}/qtgrpc \
+		-x'!'${QT_SRC_DIR}/qthttpserver \
+		-x'!'${QT_SRC_DIR}/qtlanguageserver \
+		-x'!'${QT_SRC_DIR}/qtnetworkauth \
+		-x'!'${QT_SRC_DIR}/qtopcua \
+		-x'!'${QT_SRC_DIR}/qtpositioning \
+		-x'!'${QT_SRC_DIR}/qtquick3dphysics \
+		-x'!'${QT_SRC_DIR}/qtquickeffectmaker \
+		-x'!'${QT_SRC_DIR}/qtremoteobjects \
+		-x'!'${QT_SRC_DIR}/qtmqtt \
+		-x'!'${QT_SRC_DIR}/qtmultimedia \
+		-x'!'${QT_SRC_DIR}/qtshadertools \
+		-x'!'${QT_SRC_DIR}/qtdeclarative \
+		-x'!'${QT_SRC_DIR}/qtcanvaspainter \
+		-x'!'${QT_SRC_DIR}/qtquicktimeline
   endef
 else
   define extract
@@ -209,6 +229,25 @@ qt: ${QT_SRC_DIR} ${PLATFORM_QT_DEPS}
 			-skip qtwebengine \
 			-skip qtwebsockets \
 			-skip qtwebview \
+			-skip qtquick3d \
+			-skip qtgraphs \
+			-skip qtlottie \
+			-skip qtactiveqt \
+			-skip qtcoap \
+			-skip qtgrpc \
+			-skip qthttpserver \
+			-skip qtlanguageserver \
+			-skip qtnetworkauth \
+			-skip qtopcua \
+			-skip qtpositioning \
+			-skip qtquick3dphysics \
+			-skip qtquickeffectmaker \
+			-skip qtremoteobjects \
+			-skip qtmqtt \
+			-skip qtmultimedia \
+			-skip qtshadertools \
+			-skip qtcanvaspainter \
+			-skip qtquicktimeline \
 			-DCMAKE_WrapClang_FOUND=false \
 			${PLATFORM_QT_OPTIONS}
 

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,8 @@ SKIP_MODULES := qtwebengine qt3d qtcanvas3d qtcharts qtconnectivity qtdeclarativ
                 qtopcua qtpositioning qtquick3dphysics qtquickeffectmaker \
                 qtremoteobjects qtmqtt qtshadertools qtcanvaspainter qtquicktimeline
 
+QT_CONFIGURE_SKIPS := $(addprefix -skip , $(SKIP_MODULES))
+
 ifeq (${PLATFORM},win)
   7Z_EXCLUDES := $(addprefix -x!${QT_SRC_DIR}/, $(SKIP_MODULES))
 
@@ -133,7 +135,6 @@ qt: ${QT_SRC_DIR} ${PLATFORM_QT_DEPS}
 	@echo "# Building Qt           #"
 	@echo "#########################"
 	@echo ""
-
 	# -nomake tools 
 	mkdir -p "${QT_BUILD_DIR}"
 	cd "${QT_BUILD_DIR}" && \
@@ -156,61 +157,7 @@ qt: ${QT_SRC_DIR} ${PLATFORM_QT_DEPS}
 			-no-feature-designer \
 			-nomake tests \
 			-nomake examples \
-			-skip qt3d \
-			-skip qtactiveqt \
-			-skip qtcharts \
-			-skip qtcoap \
-			-skip qtconnectivity \
-			-skip qtdatavis3d \
-			-skip qtdeclarative \
-			-skip qtdoc \
-			-skip qtgraphs \
-			-skip qtgrpc \
-			-skip qthttpserver \
-			-skip qtlanguageserver \
-			-skip qtlocation \
-			-skip qtlottie \
-			-skip qtmqtt \
-			-skip qtmultimedia \
-			-skip qtnetworkauth \
-			-skip qtopcua \
-			-skip qtpositioning \
-			-skip qtquick3d \
-			-skip qtquick3dphysics \
-			-skip qtquickeffectmaker \
-			-skip qtquicktimeline \
-			-skip qtremoteobjects \
-			-skip qtscxml \
-			-skip qtsensors \
-			-skip qtserialbus \
-			-skip qtserialport \
-			-skip qtshadertools \
-			-skip qtspeech \
-			-skip qttranslations \
-			-skip qtvirtualkeyboard \
-			-skip qtwebchannel \
-			-skip qtwebengine \
-			-skip qtwebsockets \
-			-skip qtwebview \
-			-skip qtquick3d \
-			-skip qtgraphs \
-			-skip qtlottie \
-			-skip qtactiveqt \
-			-skip qtcoap \
-			-skip qtgrpc \
-			-skip qthttpserver \
-			-skip qtlanguageserver \
-			-skip qtnetworkauth \
-			-skip qtopcua \
-			-skip qtpositioning \
-			-skip qtquick3dphysics \
-			-skip qtquickeffectmaker \
-			-skip qtremoteobjects \
-			-skip qtmqtt \
-			-skip qtmultimedia \
-			-skip qtshadertools \
-			-skip qtcanvaspainter \
-			-skip qtquicktimeline \
+			$(QT_CONFIGURE_SKIPS) \
 			-DCMAKE_WrapClang_FOUND=false \
 			${PLATFORM_QT_OPTIONS}
 

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -68,12 +68,12 @@ function DownloadAndCheckFile() {
 
 SetupVsEnv
 
-$version_base = "6.7"
-$version_full = "6.7.2"
-#$url = "https://download.qt.io/official_releases/qt/$version_base/$version_full/single/qt-everywhere-src-$version_full.zip"
-$url = "http://master.qt.io/archive/qt/$version_base/$version_full/single/qt-everywhere-src-$version_full.zip"
+$version_base = "6.11"
+$version_full = "6.11.0"
+$url = "https://download.qt.io/official_releases/qt/$version_base/$version_full/single/qt-everywhere-src-$version_full.zip"
+#$url = "http://master.qt.io/archive/qt/$version_base/$version_full/single/qt-everywhere-src-$version_full.zip"
 $output = "qt-everywhere-src-$version_full.zip"
-$hash_expected = "e71c1f1b453b2b5a34173307d2ba9d35d3383e9727fbc34dc7eef189f351bca5"
+$hash_expected = "0c8f99a4727a63262d5241201b84c883ab61617bdc5c431820073f2ebcd75ad5"
 $QT_SRC_DIR = "qt-everywhere-src-$version_full"
 $qt_build_dir = "$QT_SRC_DIR/build"
 $QT_PREFIX = "$PSScriptRoot/qt"
@@ -105,6 +105,7 @@ Write-Output "Extracting"
     -x'!'${QT_SRC_DIR}/qtserialbus `
     -x'!'${QT_SRC_DIR}/qtserialport `
     -x'!'${QT_SRC_DIR}/qtspeech `
+    -x'!'${QT_SRC_DIR}/qttranslations `
     -x'!'${QT_SRC_DIR}/qtvirtualkeyboard `
     -x'!'${QT_SRC_DIR}/qtwebglplugin `
     -x'!'${QT_SRC_DIR}/qtwebsockets `
@@ -115,7 +116,27 @@ Write-Output "Extracting"
     -x'!'${QT_SRC_DIR}/qtquickcontrols2 `
     -x'!'${QT_SRC_DIR}/qtx11extras `
     -x'!'${QT_SRC_DIR}/qtandroidextras `
-    -x'!'${QT_SRC_DIR}/qtwebchannel
+    -x'!'${QT_SRC_DIR}/qtwebchannel `
+    -x'!'${QT_SRC_DIR}/qtquick3d `
+    -x'!'${QT_SRC_DIR}/qtgraphs `
+    -x'!'${QT_SRC_DIR}/qtlottie `
+    -x'!'${QT_SRC_DIR}/qtactiveqt `
+    -x'!'${QT_SRC_DIR}/qtcoap `
+    -x'!'${QT_SRC_DIR}/qtgrpc `
+    -x'!'${QT_SRC_DIR}/qthttpserver `
+    -x'!'${QT_SRC_DIR}/qtlanguageserver `
+    -x'!'${QT_SRC_DIR}/qtnetworkauth `
+    -x'!'${QT_SRC_DIR}/qtopcua `
+    -x'!'${QT_SRC_DIR}/qtpositioning `
+    -x'!'${QT_SRC_DIR}/qtquick3dphysics `
+    -x'!'${QT_SRC_DIR}/qtquickeffectmaker `
+    -x'!'${QT_SRC_DIR}/qtremoteobjects `
+    -x'!'${QT_SRC_DIR}/qtmqtt `
+    -x'!'${QT_SRC_DIR}/qtmultimedia `
+    -x'!'${QT_SRC_DIR}/qtshadertools `
+    -x'!'${QT_SRC_DIR}/qtdeclarative `
+    -x'!'${QT_SRC_DIR}/qtcanvaspainter `
+    -x'!'${QT_SRC_DIR}/qtquicktimeline
 if (-not $?) {
     Fatal-Error "Failed to extract source"
 }
@@ -126,7 +147,7 @@ Write-Output "build dir '$qt_build_dir'"
 Set-Location -Path $qt_build_dir
 Write-Output "Current dir"
 Get-Location
-cmd /c "..\configure.bat -prefix `"${QT_PREFIX}`" -opensource -confirm-license -release -qt-libpng -qt-libjpeg -no-feature-cups -no-feature-icu -no-sql-db2 -no-sql-ibase -no-sql-mysql -no-sql-oci -no-sql-odbc -no-sql-psql -no-sql-sqlite -no-feature-assistant -no-feature-clang -no-feature-designer -nomake tests -nomake examples -skip qt3d -skip qtactiveqt -skip qtcharts -skip qtcoap -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgrpc -skip qtgraphs -skip qthttpserver -skip qtlanguageserver -skip qtlocation -skip qtlottie -skip qtmqtt -skip qtmultimedia -skip qtnetworkauth -skip qtopcua -skip qtpositioning -skip qtquick3d -skip qtquick3dphysics -skip qtquickeffectmaker -skip qtquicktimeline -skip qtremoteobjects -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtshadertools -skip qtspeech -skip qttranslations -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwebview -skip qtwayland -skip qtmacextras -skip qtx11extras 2>&1"
+cmd /c "..\configure.bat -prefix `"${QT_PREFIX}`" -opensource -confirm-license -release -qt-libpng -qt-libjpeg -no-feature-cups -no-feature-icu -no-sql-db2 -no-sql-ibase -no-sql-mysql -no-sql-oci -no-sql-odbc -no-sql-psql -no-sql-sqlite -no-feature-assistant -no-feature-clang -no-feature-designer -nomake tests -nomake examples -skip qt3d -skip qtactiveqt -skip qtcharts -skip qtcoap -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgrpc -skip qtgraphs -skip qthttpserver -skip qtlanguageserver -skip qtlocation -skip qtlottie -skip qtmqtt -skip qtmultimedia -skip qtnetworkauth -skip qtopcua -skip qtpositioning -skip qtquick3d -skip qtquick3dphysics -skip qtquickeffectmaker -skip qtquicktimeline -skip qtremoteobjects -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtshadertools -skip qtspeech -skip qttranslations -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwebview -skip qtwayland -skip qtmacextras -skip qtx11extras -skip	qtquick3d -skip	qtgraphs -skip qtlottie -skip	qtactiveqt -skip qtcoap -skip	qtgrpc -skip qthttpserver -skip	qtlanguageserver -skip qtnetworkauth -skip qtopcua -skip	qtpositioning -skip	qtquick3dphysics -skip qtquickeffectmaker -skip	qtremoteobjects -skip	qtmqtt -skip qtmultimedia -skip	qtshadertools -skip	qtcanvaspainter -skip	qtquicktimeline 2>&1"
 if (-not $?) {
      Fatal-Error "Failed to configure qt"
 }


### PR DESCRIPTION
* Update outdated runners 
* Use llvm-20
* Update from qt 6.7.2 to qt 6.11.0 to support shiboken6.11 and pyside 6.11
* Skip modules not needed by cutter

All of these changes are tested on a fork beforehand including the future changes in `cutter-deps` and `cutter` :)

Since I don't have write access to this repo, a maintainer will have to make a release by pushing a new tag after this is merged
Will open PRs in `cutter-deps` and `cutter` after this release